### PR TITLE
Fix updating Python requirements upon soup self-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
+# Test SM installation
 NeotokyoSource/
+# Temp backups
+bak/
+# Don't store requirements installation stuff
 Pipfile
 Pipfile.lock
 
 ##############################################################################
-# Ignores below this comment are from:
+# Ignores below this comment block are from GitHub's .gitignore templates repo:
 # https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
 ##############################################################################
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ There are three valid recipe sections: _updater_, _includes_, and _plugins_. Exa
 	"updater": [
 		{
 			"version": "1.3.0",
-			"url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@main"
+			"url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@1.3.0"
 		}
 	]
 ```

--- a/README.md
+++ b/README.md
@@ -33,26 +33,17 @@ It is recommended to use the [latest release](https://github.com/CreamySoup/soup
 
 You should also consider using a [pipenv](https://github.com/pypa/pipenv) or [virtual environment](https://docs.python.org/3/library/venv.html) to isolate any Python dependencies from the rest of the system (although if you go this route, any cron job or similar automation should also run inside that env to have access to those deps).
 
-Example (Linux):
+Example:
 ```sh
-whereis python # system Python install location
+# Install/upgrade pipenv
+pip3 install --user --upgrade pipenv
 
-# Create a Python virtual environment
-pip3 install --user --upgrade pipenv && pipenv --three
+# Install soup.py requirements inside a Python 3 virtual environment
+pipenv install --three
 
-# Enter the virtual environment
-pipenv --shell
-
-whereis python # venv Python install location
-
-# Install requirements from requirements.txt
-pipenv install
-
-# Run the script
-python ./soup
-
-# Exit virtual environment
-exit
+# Run soup.py inside the created virtual env, then exit the virtual env.
+# This would be the cron-scheduled command.
+pipenv run python soup.py
 ```
 
 ### Other requirements
@@ -97,13 +88,13 @@ Note that trailing commas are not allowed in the JSON syntax – it's a good ide
 
 There are three valid recipe sections: _updater_, _includes_, and _plugins_. Examples follow:
 
-* **updater** – A self-updater section for the soup.py script contents. Only one section in total of this kind should exist at most in all of the recipes being used.
+* **updater** – A self-updater section for the soup.py script contents and its _requirements.txt_. Only one section in total of this kind should exist at most in all of the recipes being used. The `url` key should be a partial URL string, which can be appended with `/soup.py` and `/requirements.txt` to fetch those resources.
 
 ```json
 	"updater": [
 		{
-			"version": "1.1.0",
-			"url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@main/soup.py"
+			"version": "1.3.0",
+			"url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@main"
 		}
 	]
 ```

--- a/config.yml
+++ b/config.yml
@@ -20,5 +20,5 @@ verbosity: 1
 # List of URLs to JSON files from which to query for updates.
 # Please see the relevant documentation for required JSON file syntax.
 recipes:
-    - https://cdn.jsdelivr.net/gh/CreamySoup/soup@self_update_deps/recipe_selfupdate.json
+    - https://cdn.jsdelivr.net/gh/CreamySoup/soup@main/recipe_selfupdate.json
     - https://cdn.jsdelivr.net/gh/CreamySoup/recipe-neotokyo@main/neotokyo_common.json

--- a/config.yml
+++ b/config.yml
@@ -20,5 +20,5 @@ verbosity: 1
 # List of URLs to JSON files from which to query for updates.
 # Please see the relevant documentation for required JSON file syntax.
 recipes:
-    - https://cdn.jsdelivr.net/gh/CreamySoup/soup@main/recipe_selfupdate.json
+    - https://cdn.jsdelivr.net/gh/CreamySoup/soup@self_update_deps/recipe_selfupdate.json
     - https://cdn.jsdelivr.net/gh/CreamySoup/recipe-neotokyo@main/neotokyo_common.json

--- a/recipe_selfupdate.json
+++ b/recipe_selfupdate.json
@@ -1,8 +1,8 @@
 {
     "updater": [
         {
-            "version": "1.2.1",
-            "url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@1.2.1/soup.py"
+            "version": "1.3.0",
+            "url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@self_update_deps"
         }
     ]
 }

--- a/recipe_selfupdate.json
+++ b/recipe_selfupdate.json
@@ -2,7 +2,7 @@
     "updater": [
         {
             "version": "1.3.0",
-            "url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@self_update_deps"
+            "url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@main"
         }
     ]
 }

--- a/recipe_selfupdate.json
+++ b/recipe_selfupdate.json
@@ -2,7 +2,7 @@
     "updater": [
         {
             "version": "1.3.0",
-            "url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@main"
+            "url": "https://cdn.jsdelivr.net/gh/CreamySoup/soup@1.3.0"
         }
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 appdirs==1.4.4
+pipenv==2021.11.23
 strictyaml==1.5.0


### PR DESCRIPTION
Run the pip requirements installation command when self-updating
so that script dependencies also stay in sync.

This is a breaking change from 1.2.x, since:
* 1.2 doesn't have the ability to self-update requirements.txt
* the self-update recipe syntax has changed